### PR TITLE
中文版下autoref的描述修改

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -22,6 +22,20 @@
 %% Hyperref
 \usepackage[breaklinks,colorlinks,citecolor=red,urlcolor=blue,bookmarks=false,hypertexnames=true]{hyperref}
 % 如需要书签，bookmarks的值改为true
+\def\equationautorefname{式}%
+\def\footnoteautorefname{脚注}%
+\def\itemautorefname{项}%
+\def\figureautorefname{图}%
+\def\tableautorefname{表}%
+\def\partautorefname{篇}%
+\def\appendixautorefname{附录}%
+\def\chapterautorefname{章}%
+\def\sectionautorefname{节}%
+\def\subsectionautorefname{小小节}%
+\def\paragraphautorefname{段落}%
+\def\subparagraphautorefname{子段落}%
+\def\FancyVerbLineautorefname{行}%
+\def\theoremautorefname{定理}%
 
 \usepackage[boxed,linesnumbered,algochapter]{algorithm2e}
 \usepackage[sort&compress]{gbt7714}

--- a/main.tex
+++ b/main.tex
@@ -22,20 +22,6 @@
 %% Hyperref
 \usepackage[breaklinks,colorlinks,citecolor=red,urlcolor=blue,bookmarks=false,hypertexnames=true]{hyperref}
 % 如需要书签，bookmarks的值改为true
-\def\equationautorefname{式}%
-\def\footnoteautorefname{脚注}%
-\def\itemautorefname{项}%
-\def\figureautorefname{图}%
-\def\tableautorefname{表}%
-\def\partautorefname{篇}%
-\def\appendixautorefname{附录}%
-\def\chapterautorefname{章}%
-\def\sectionautorefname{节}%
-\def\subsectionautorefname{小小节}%
-\def\paragraphautorefname{段落}%
-\def\subparagraphautorefname{子段落}%
-\def\FancyVerbLineautorefname{行}%
-\def\theoremautorefname{定理}%
 
 \usepackage[boxed,linesnumbered,algochapter]{algorithm2e}
 \usepackage[sort&compress]{gbt7714}
@@ -68,6 +54,20 @@
 \else
   % Chinese
   \zihao{-4}\setlength{\baselineskip}{20bp}
+  \def\equationautorefname{式}%
+  \def\footnoteautorefname{脚注}%
+  \def\itemautorefname{项}%
+  \def\figureautorefname{图}%
+  \def\tableautorefname{表}%
+  \def\partautorefname{篇}%
+  \def\appendixautorefname{附录}%
+  \def\chapterautorefname{章}%
+  \def\sectionautorefname{节}%
+  \def\subsectionautorefname{小小节}%
+  \def\paragraphautorefname{段落}%
+  \def\subparagraphautorefname{子段落}%
+  \def\FancyVerbLineautorefname{行}%
+  \def\theoremautorefname{定理}%
 \fi
 
 \tableofcontents


### PR DESCRIPTION
正文中如果使用\autoref，\autoref的文本描述还是英文版的。
例如，尽管插入的图片的caption描述是图1：blah blah，\autoref 的描述却是 figure 1

